### PR TITLE
Fix css in .affinity.-all

### DIFF
--- a/website/cards.css
+++ b/website/cards.css
@@ -192,5 +192,5 @@
 }
 
 .affinity.-all {
-	background-image: linear-gradient( 135deg, red, red 37%, green 22%, green 50%, blue 66%, blue );
+	background-image: linear-gradient( 135deg, red, red 33%, green 33%, green 66%, blue 66%, blue );
 }


### PR DESCRIPTION
Fixed the ".affinity.-all" css.  The old version was overlapping colors.  This can be seen on the Nebulae ability card.